### PR TITLE
updated whitelist to allow text formatting and updated tests

### DIFF
--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -151,8 +151,6 @@ public class ChatServlet extends HttpServlet {
     // reference for this whitelist can be found here: https://jsoup.org/apidocs/org/jsoup/safety/Whitelist.html#basic--
     String cleanedMessageContent = Jsoup.clean(messageContent, "", Whitelist.basic(), settings);
 
-    cleanedMessageContent = replaceUrls(cleanedMessageContent);
-
     Message message =
         new Message(
             UUID.randomUUID(),

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -29,6 +29,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document.OutputSettings;
 import org.jsoup.safety.Whitelist;
 
 /** Servlet class responsible for the chat page. */
@@ -141,10 +142,16 @@ public class ChatServlet extends HttpServlet {
 
     String messageContent = request.getParameter("message");
 
-    // this removes any HTML from the message content
-    // altered the whitelist so that text modifiers aren't removed
-    String cleanedMessageContent = Jsoup.clean(messageContent, Whitelist.basic());
-    System.out.println(cleanedMessageContent);
+
+    // adjusted settings for cleaning done by Jsoup
+    OutputSettings settings = new OutputSettings();
+    settings.prettyPrint(false);  
+
+    // this removes all HTML tags except for text nodes (a, b, blockquote, li, ol)
+    // reference for this whitelist can be found here: https://jsoup.org/apidocs/org/jsoup/safety/Whitelist.html#basic--
+    String cleanedMessageContent = Jsoup.clean(messageContent, "", Whitelist.basic(), settings);
+
+    cleanedMessageContent = replaceUrls(cleanedMessageContent);
 
     Message message =
         new Message(

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -43,6 +43,7 @@ public class ChatServlet extends HttpServlet {
   /** Store class that gives access to Users. */
   private UserStore userStore;
 
+
   /** Set up state for handling chat requests. */
   @Override
   public void init() throws ServletException {
@@ -141,7 +142,9 @@ public class ChatServlet extends HttpServlet {
     String messageContent = request.getParameter("message");
 
     // this removes any HTML from the message content
-    String cleanedMessageContent = Jsoup.clean(messageContent, Whitelist.none());
+    // altered the whitelist so that text modifiers aren't removed
+    String cleanedMessageContent = Jsoup.clean(messageContent, Whitelist.basic());
+    System.out.println(cleanedMessageContent);
 
     Message message =
         new Message(

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -206,8 +206,11 @@ public class ChatServletTest {
 
     ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
     Mockito.verify(mockMessageStore).addMessage(messageArgumentCaptor.capture());
+    
+    // so this is really weird. I have to include a newline escape key before the <b> tag for this test to pass
+    // Anyone have any idea why?
     Assert.assertEquals(
-        "Contains html and  content.", messageArgumentCaptor.getValue().getContent());
+        "Contains \n<b>html</b> and  content.", messageArgumentCaptor.getValue().getContent());
 
     Mockito.verify(mockResponse).sendRedirect("/chat/test_conversation");
   }

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -214,7 +214,7 @@ public class ChatServletTest {
   }
 
   @Test
-  public void testDoPost_CleansHtmlContent2() throws IOException, ServletException {
+  public void testDoPost_AllowsTextTags() throws IOException, ServletException {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
@@ -244,4 +244,37 @@ public class ChatServletTest {
 
     Mockito.verify(mockResponse).sendRedirect("/chat/test_conversation");
   }
+
+  @Test
+  public void testDoPost_RemovesBadTags() throws IOException, ServletException {
+    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
+    Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
+
+    User fakeUser =
+        new User(
+            UUID.randomUUID(),
+            "test_username",
+            "$2a$10$eDhncK/4cNH2KE.Y51AWpeL8/5znNBQLuAFlyJpSYNODR/SJQ/Fg6",
+            Instant.now());
+    Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
+
+    Conversation fakeConversation =
+        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
+    Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
+        .thenReturn(fakeConversation);
+
+    Mockito.when(mockRequest.getParameter("message"))
+        .thenReturn("This message contains <script>malicious</script> content. We should remove nontext stuff like <div>this</div>");
+
+    chatServlet.doPost(mockRequest, mockResponse);
+
+    ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
+    Mockito.verify(mockMessageStore).addMessage(messageArgumentCaptor.capture());
+    
+    Assert.assertEquals(
+        "This message contains  content. We should remove nontext stuff like this", messageArgumentCaptor.getValue().getContent());
+
+    Mockito.verify(mockResponse).sendRedirect("/chat/test_conversation");
+  }
+
 }

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -207,10 +207,40 @@ public class ChatServletTest {
     ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
     Mockito.verify(mockMessageStore).addMessage(messageArgumentCaptor.capture());
     
-    // so this is really weird. I have to include a newline escape key before the <b> tag for this test to pass
-    // Anyone have any idea why?
     Assert.assertEquals(
-        "Contains \n<b>html</b> and  content.", messageArgumentCaptor.getValue().getContent());
+        "Contains <b>html</b> and  content.", messageArgumentCaptor.getValue().getContent());
+
+    Mockito.verify(mockResponse).sendRedirect("/chat/test_conversation");
+  }
+
+  @Test
+  public void testDoPost_CleansHtmlContent2() throws IOException, ServletException {
+    Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
+    Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
+
+    User fakeUser =
+        new User(
+            UUID.randomUUID(),
+            "test_username",
+            "$2a$10$eDhncK/4cNH2KE.Y51AWpeL8/5znNBQLuAFlyJpSYNODR/SJQ/Fg6",
+            Instant.now());
+    Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
+
+    Conversation fakeConversation =
+        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
+    Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
+        .thenReturn(fakeConversation);
+
+    Mockito.when(mockRequest.getParameter("message"))
+        .thenReturn("Contains <b>html</b> and <script>JavaScript</script> content. This should be <em>included</em>");
+
+    chatServlet.doPost(mockRequest, mockResponse);
+
+    ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
+    Mockito.verify(mockMessageStore).addMessage(messageArgumentCaptor.capture());
+    
+    Assert.assertEquals(
+        "Contains <b>html</b> and  content. This should be <em>included</em>", messageArgumentCaptor.getValue().getContent());
 
     Mockito.verify(mockResponse).sendRedirect("/chat/test_conversation");
   }


### PR DESCRIPTION
I changed the whitelist to allow certain html tags to be used:

- <b>bold</b>
- <i>italics</i>
- list items
- <strike>strike through</strike>
- others

I also had to update a unit test to reflect this change. I was having a weird issue where I had to use a newline escape key to get the test to pass. If anyone has any idea why that's the case please let me know; stackoverflow's been no help on this one.